### PR TITLE
Adds: Persistence to Keycloak using Postgres Database

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ When Keycloak up and running (when `docker-compose logs oidc_kc` shows `Admin co
 
 That restarts the IdP and so will take 20 seconds or so.
 
+Once configured, patch the Postgres database to make User's profile `Attributes` `Value` to be `VARCHAR`.
+
+```
+./oidc/modify_postgres.sh
+```
+
 ## Loging in as realm admin
 
 Now log in to the mockrealm admin console with username user1/pass1 at: http://127.0.0.1:8080/auth/admin/mockrealm/console/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,9 +9,27 @@ services:
     volumes:
       - ./oidc/tls.crt:/etc/x509/https/tls.crt
       - ./oidc/tls.key:/etc/x509/https/tls.key
+      - ./pgdata:/opt/jboss/keycloak/standalone/data
     environment:
       KEYCLOAK_USER: kcadmin
       KEYCLOAK_PASSWORD: admin
+      DB_VENDOR: POSTGRES
+      DB_ADDR: postgresdb
+      DB_DATABASE: keycloak
+      DB_USER: keycloak
+      DB_PASSWORD: keycloak
+
+  postgresdb:
+    container_name: postgresdb
+    image: postgres
+    ports:
+      - "5432:5432"
+    restart: always
+    volumes:
+      - ./oidc/setup_postgres.sh:/tmp/setup_postgres.sh
+    environment:
+      POSTGRES_USER: keycloak
+      POSTGRES_PASSWORD: keycloak
 
   ldap_mock:
     container_name: ldap

--- a/generate-certs.sh
+++ b/generate-certs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 openssl genrsa -des3 -out rootCA.key 4096

--- a/ldap_mock/config_ldap
+++ b/ldap_mock/config_ldap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 docker cp ldap_mock/mock_users.ldif ldap:/tmp

--- a/oidc/config-oidc-service
+++ b/oidc/config-oidc-service
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 for file in config.sh oidc/setup_keycloak_{realm,user_roles}.sh

--- a/oidc/modify_postgres.sh
+++ b/oidc/modify_postgres.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# Copied from Dash's changes to `candig_compose`
+# Only need to run this script for a fresh Postgres deployment
+
+
+echo "Modifying Postgres Container"
+docker exec postgresdb ./tmp/setup_postgres.sh
+wait
+
+echo "Confirming schema alterations"
+VERIFY=`docker exec postgresdb psql -X -A -U keycloak -c "\d+ user_attribute" | grep -o "value|character varying|"`
+
+if [ "$VERIFY" = "value|character varying|" ] ; then
+    echo "Verified"
+else
+    echo "Error. Schema not changed. Rerun this script."
+fi

--- a/oidc/setup_postgres.sh
+++ b/oidc/setup_postgres.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# This script checks the schemas within Postgres and modifies Keycloak's user_attribute
+# table to utilize a VARCHAR value of indeterminate length rather than the base 255 characters.
+
+# The main loop will continue until the schema is found, which should occur once the Keycloak
+# container is fully operational.
+
+
+while true
+do
+    EXISTS=`psql -X -A -U keycloak -c "SELECT EXISTS (
+        SELECT FROM information_schema.tables
+        WHERE table_name = 'user_attribute'
+        );"`
+
+    if [ $(echo "$EXISTS" | sed '2q;d') = "t" ]; then
+        echo "Schema exists, altering user_attribute table"
+        psql -X -A -U keycloak -c "
+        ALTER TABLE user_attribute
+        ALTER COLUMN value TYPE VARCHAR;
+        "
+        echo "Schema Updated"
+        break
+    fi
+done
+
+echo "Confirming schema update"
+VERIFY=`psql -X -A -U keycloak -c "\d+ user_attribute" | grep -o "value|character varying|"`
+
+if [ "$VERIFY" = "value|character varying|" ] ; then
+    echo "Verified"
+else
+    echo not Found
+fi

--- a/oidc/test_scripts/get_token_any_user.sh
+++ b/oidc/test_scripts/get_token_any_user.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source config.sh
 
 readonly defaultuser="None"

--- a/oidc/test_scripts/get_token_user1.sh
+++ b/oidc/test_scripts/get_token_user1.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 
 source config.sh
 

--- a/oidc/test_scripts/introspect.sh
+++ b/oidc/test_scripts/introspect.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #set -euo pipefail
 
 readonly token=${1:-"notoken"}

--- a/oidc/test_scripts/userinfo.sh
+++ b/oidc/test_scripts/userinfo.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 readonly token=${1:-"notoken"}

--- a/oidc/test_scripts/wellknown.sh
+++ b/oidc/test_scripts/wellknown.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 source config.sh


### PR DESCRIPTION
This PR 

- Adds a Postgres database for Keycloak instance to make the data persistent. It stores the data on a mounted volume for the container and as long as the containers are only stopped `docker-compose stop`, the data and container settings should be retained.
- Adds scripts for Postgres database to be patched for storing larger user attribute values.
- Fixes minor bash script shebang to use `env` rather than hard coded `/bin/bash`.

cc @dashaylan 